### PR TITLE
Update getFilePath for SPA support

### DIFF
--- a/src/utils/getFilePath.js
+++ b/src/utils/getFilePath.js
@@ -2,9 +2,13 @@ import fs from 'fs';
 import { options } from '../index.js';
 
 export const getFilePath = request => {
-	const { root } = options;
+	const { root, fallback } = options;
 
 	if (request.url == '/') return `${root}/index.html`;
+
+	if (fallback && !fs.existsSync(`${root}${request.url}`) && !request.url.endsWith('/')) {
+		return `${root}/${fallback}`;
+	}
 
 	if (!request.url.includes('.')) {
 		const testFilepath = `${root}/${request.url}.html`;


### PR DESCRIPTION
Hi there!

This is a great and tiny project. I began using this in conjunction with esbuild for a couple projects.

I was surprised to learn that Single-Page App support wasn't included. I forked your repo and added this for myself., but would like to see if you'd like to have it upstream. Feedback welcome.

With these changes, if you wanted to serve an SPA, you would need to add a `fallback` property to the `options` object you pass to `serve.start`. In the case of SPAs, you'd probably want the fallback to be `index.html`. So:

```js
serve.start({
    port: 7000,
    root: '.',
    live: true,
    fallback: 'index.html'
});
```

EDIT: For the record, I did see and test #1 but was confused by the PR description and personally, that solution did not work in my project.