### PR TITLE
Update getIp.js, fails on ubuntu

### DIFF
--- a/src/utils/getIp.js
+++ b/src/utils/getIp.js
@@ -3,4 +3,4 @@ import { networkInterfaces } from 'os';
 export const getIp = () =>
 	Object.values(networkInterfaces())
 		.flat()
-		.find(ip => ip.family == 'IPv4' && !ip.internal).address;
+		.find(ip => (ip.family == 'IPv4' || ip.family == 4) && !ip.internal).address;


### PR DESCRIPTION
In ubuntu `ip.family` is returned as a number.